### PR TITLE
Update for the Repo package 1.1.12-1 release

### DIFF
--- a/SPECS/RHEL6/pcs.spec
+++ b/SPECS/RHEL6/pcs.spec
@@ -9,7 +9,7 @@ BuildRequires: python2-devel
 Summary: Pacemaker Configuration System	
 Source0: pcs-%{version}.tar.gz
 
-Requires: pacemaker ccs	
+Requires: pacemaker
 
 %description
 pcs is a corosync and pacemaker configuration tool.  It permits users to


### PR DESCRIPTION
Drop ccs dependency from the pcs spec file.

pcs only supports the cman cluster on RHEL6 in official,
and this Repo package provides the brand new corosync cluster.
The pcs in this packages can be used only for Pacemaker configuration,
and not for cman/corosync configuration.
