### PR TITLE
Update spec files for 1.1.13-0.rc1.el6

### DIFF
--- a/SPECS/RHEL6/0021-revert.patch
+++ b/SPECS/RHEL6/0021-revert.patch
@@ -1,0 +1,13 @@
+diff --git a/fence/agents/kdump/Makefile.am b/fence/agents/kdump/Makefile.am
+index 2195f64..494f2b8 100644
+--- a/fence/agents/kdump/Makefile.am
++++ b/fence/agents/kdump/Makefile.am
+@@ -1,7 +1,6 @@
+ MAINTAINERCLEANFILES		= Makefile.in
+ 
+-sbin_PROGRAMS			= fence_kdump
+-libexec_PROGRAMS		= fence_kdump_send
++sbin_PROGRAMS			= fence_kdump fence_kdump_send
+ 
+ noinst_HEADERS			= list.h message.h options.h version.h
+ 

--- a/SPECS/RHEL6/fence-agents.spec
+++ b/SPECS/RHEL6/fence-agents.spec
@@ -27,7 +27,7 @@ Patch0: 0021-revert.patch
 ExclusiveArch: i686 x86_64
 
 # shipped agents
-%global supportedagents apc apc_snmp bladecenter brocade cisco_mds cisco_ucs drac drac5 eaton_snmp emerson eps hpblade kdump ibmblade ifmib ilo ilo_moonshot ilo_mp ilo_ssh intelmodular ipdu ipmilan manual mpath rhevm rsb scsi wti vmware_soap
+%global supportedagents apc apc_snmp bladecenter brocade cisco_mds cisco_ucs compute drac drac5 eaton_snmp emerson eps hpblade kdump ibmblade ifmib ilo ilo_moonshot ilo_mp ilo_ssh intelmodular ipdu ipmilan manual mpath rhevm rsb scsi wti vmware_soap
 %global deprecated rsa sanbox2
 %global testagents virsh vmware
 %global requiresthirdparty %{nil}

--- a/SPECS/RHEL6/fence-agents.spec
+++ b/SPECS/RHEL6/fence-agents.spec
@@ -15,47 +15,13 @@
 
 Name: fence-agents
 Summary: Fence Agents for Red Hat Cluster
-Version: 4.0.15
-Release: 8%{?alphatag:.%{alphatag}}%{?dist}
+Version: 4.0.19
+Release: 1%{?alphatag:.%{alphatag}}%{?dist}
 License: GPLv2+ and LGPLv2+
 Group: System Environment/Base
 URL: http://sources.redhat.com/cluster/wiki/
-Source0: https://fedorahosted.org/releases/f/e/fence-agents/%{name}-%{version}.tar.bz2
+Source0: %{name}-%{version}.tar.bz2
 
-Patch0: 0001-revert.patch
-Patch1: 0002-revert.patch
-Patch2: 0003-revert.patch
-Patch3: 0004-revert.patch
-Patch4: 0005-revert.patch
-Patch5: 0006-revert.patch
-Patch6: 0007-revert.patch
-Patch7: 0008-revert.patch
-Patch8: 0009-revert.patch
-Patch9: 0010-revert.patch
-Patch10: 0011-revert.patch
-Patch11: 0012-revert.patch
-Patch12: 0013-revert.patch
-Patch13: 0014-revert.patch
-Patch14: 0015-revert.patch
-Patch15: 0016-revert.patch
-Patch16: 0017-revert.patch
-Patch17: 0018-revert.patch
-Patch18: 0019-revert.patch
-Patch19: 0020-revert.patch
-Patch20: 0021-revert.patch
-Patch21: 0022-revert.patch
-Patch22: 0023-revert.patch
-Patch23: 0024-revert.patch
-Patch24: bz1094515-fence_kdump-monitor.patch
-Patch25: bz1094515-2-fence_kdump-monitor.patch
-Patch26: bz1094515-3-fence_kdump-monitor.patch
-Patch27: bz1094515-4-fence_kdump-monitor.patch
-Patch28: bz1049805-rebase_ipmi_unset_cipher.patch
-Patch29: bz1049805-rebase_bladecenter.patch
-Patch30: bz1049805-rebase_remove_python_scsi.patch
-Patch31: bz1049805-rebase_tls.patch
-Patch32: bz1118008-1-fence_mpath_metadata.patch
-Patch33: bz1118008-2-fence_mpath_metadata.patch
 
 ExclusiveArch: i686 x86_64
 
@@ -63,7 +29,7 @@ ExclusiveArch: i686 x86_64
 %global supportedagents apc apc_snmp bladecenter brocade cisco_mds cisco_ucs drac drac5 eaton_snmp emerson eps hpblade kdump ibmblade ifmib ilo ilo_moonshot ilo_mp ilo_ssh intelmodular ipdu ipmilan manual mpath rhevm rsb scsi wti vmware_soap
 %global deprecated rsa sanbox2
 %global testagents virsh vmware
-%global requiresthirdparty egenera
+%global requiresthirdparty %{nil}
 
 ## Runtime deps
 Requires: sg3_utils telnet openssh-clients
@@ -97,40 +63,6 @@ BuildRequires: device-mapper-multipath
 %prep
 %setup -q -n %{name}-%{version}
 
-%patch0 -p1 -b .revert01
-%patch1 -p1 -b .revert02
-%patch2 -p1 -b .revert03
-%patch3 -p1 -b .revert04
-%patch4 -p1 -b .revert05
-%patch5 -p1 -b .revert06
-%patch6 -p1 -b .revert07
-%patch7 -p1 -b .revert08
-%patch8 -p1 -b .revert09
-%patch9 -p1 -b .revert10
-%patch10 -p1 -b .revert11
-%patch11 -p1 -b .revert12
-%patch12 -p1 -b .revert13
-%patch13 -p1 -b .revert14
-%patch14 -p1 -b .revert15
-%patch15 -p1 -b .revert16
-%patch16 -p1 -b .revert17
-%patch17 -p1 -b .revert18
-%patch18 -p1 -b .revert19
-%patch19 -p1 -b .revert20
-%patch20 -p1 -b .revert21
-%patch21 -p1 -b .revert22
-%patch22 -p1 -b .revert23
-%patch23 -p1 -b .revert24
-%patch24 -p1 -b .bz1094515
-%patch25 -p1 -b .bz1094515.2
-%patch26 -p1 -b .bz1094515.3
-%patch27 -p1 -b .bz1094515.4
-%patch28 -p1 -b .bz1049805.1
-%patch29 -p1 -b .bz1049805.2
-%patch30 -p1 -b .bz1049805.3
-%patch31 -p1 -b .bz1049805.4
-%patch32 -p1 -b .bz1118008.1
-%patch33 -p1 -b .bz1118008.2
 
 %build
 ./autogen.sh

--- a/SPECS/RHEL6/fence-agents.spec
+++ b/SPECS/RHEL6/fence-agents.spec
@@ -15,27 +15,61 @@
 
 Name: fence-agents
 Summary: Fence Agents for Red Hat Cluster
-Version: 4.0.10
-Release: 1%{?alphatag:.%{alphatag}}%{?dist}
+Version: 4.0.15
+Release: 8%{?alphatag:.%{alphatag}}%{?dist}
 License: GPLv2+ and LGPLv2+
 Group: System Environment/Base
 URL: http://sources.redhat.com/cluster/wiki/
-Source0: fence-agents/%{name}-%{version}.tar.bz2
+Source0: https://fedorahosted.org/releases/f/e/fence-agents/%{name}-%{version}.tar.bz2
 
+Patch0: 0001-revert.patch
+Patch1: 0002-revert.patch
+Patch2: 0003-revert.patch
+Patch3: 0004-revert.patch
+Patch4: 0005-revert.patch
+Patch5: 0006-revert.patch
+Patch6: 0007-revert.patch
+Patch7: 0008-revert.patch
+Patch8: 0009-revert.patch
+Patch9: 0010-revert.patch
+Patch10: 0011-revert.patch
+Patch11: 0012-revert.patch
+Patch12: 0013-revert.patch
+Patch13: 0014-revert.patch
+Patch14: 0015-revert.patch
+Patch15: 0016-revert.patch
+Patch16: 0017-revert.patch
+Patch17: 0018-revert.patch
+Patch18: 0019-revert.patch
+Patch19: 0020-revert.patch
+Patch20: 0021-revert.patch
+Patch21: 0022-revert.patch
+Patch22: 0023-revert.patch
+Patch23: 0024-revert.patch
+Patch24: bz1094515-fence_kdump-monitor.patch
+Patch25: bz1094515-2-fence_kdump-monitor.patch
+Patch26: bz1094515-3-fence_kdump-monitor.patch
+Patch27: bz1094515-4-fence_kdump-monitor.patch
+Patch28: bz1049805-rebase_ipmi_unset_cipher.patch
+Patch29: bz1049805-rebase_bladecenter.patch
+Patch30: bz1049805-rebase_remove_python_scsi.patch
+Patch31: bz1049805-rebase_tls.patch
+Patch32: bz1118008-1-fence_mpath_metadata.patch
+Patch33: bz1118008-2-fence_mpath_metadata.patch
 
 ExclusiveArch: i686 x86_64
 
 # shipped agents
-%global supportedagents apc apc_snmp bladecenter brocade cisco_mds cisco_ucs drac drac5 eaton_snmp eps hpblade kdump ibmblade ifmib ilo ilo_mp intelmodular ipdu ipmilan manual rhevm rsb scsi wti vmware_soap
+%global supportedagents apc apc_snmp bladecenter brocade cisco_mds cisco_ucs drac drac5 eaton_snmp emerson eps hpblade kdump ibmblade ifmib ilo ilo_moonshot ilo_mp ilo_ssh intelmodular ipdu ipmilan manual mpath rhevm rsb scsi wti vmware_soap
 %global deprecated rsa sanbox2
 %global testagents virsh vmware
-%global requiresthirdparty %{nil}
+%global requiresthirdparty egenera
 
 ## Runtime deps
 Requires: sg3_utils telnet openssh-clients
 Requires: pexpect net-snmp-utils
 Requires: perl-Net-Telnet python-pycurl pyOpenSSL
-Requires: python-suds
+Requires: python-suds gnutls-utils
 
 # This is required by fence_virsh. Per discussion on fedora-devel
 # switching from package to file based require.
@@ -58,10 +92,45 @@ BuildRequires: python-pycurl
 BuildRequires: python-suds
 BuildRequires: automake autoconf pkgconfig libtool
 BuildRequires: net-snmp-utils perl-Net-Telnet
+BuildRequires: device-mapper-multipath
 
 %prep
 %setup -q -n %{name}-%{version}
 
+%patch0 -p1 -b .revert01
+%patch1 -p1 -b .revert02
+%patch2 -p1 -b .revert03
+%patch3 -p1 -b .revert04
+%patch4 -p1 -b .revert05
+%patch5 -p1 -b .revert06
+%patch6 -p1 -b .revert07
+%patch7 -p1 -b .revert08
+%patch8 -p1 -b .revert09
+%patch9 -p1 -b .revert10
+%patch10 -p1 -b .revert11
+%patch11 -p1 -b .revert12
+%patch12 -p1 -b .revert13
+%patch13 -p1 -b .revert14
+%patch14 -p1 -b .revert15
+%patch15 -p1 -b .revert16
+%patch16 -p1 -b .revert17
+%patch17 -p1 -b .revert18
+%patch18 -p1 -b .revert19
+%patch19 -p1 -b .revert20
+%patch20 -p1 -b .revert21
+%patch21 -p1 -b .revert22
+%patch22 -p1 -b .revert23
+%patch23 -p1 -b .revert24
+%patch24 -p1 -b .bz1094515
+%patch25 -p1 -b .bz1094515.2
+%patch26 -p1 -b .bz1094515.3
+%patch27 -p1 -b .bz1094515.4
+%patch28 -p1 -b .bz1049805.1
+%patch29 -p1 -b .bz1049805.2
+%patch30 -p1 -b .bz1049805.3
+%patch31 -p1 -b .bz1049805.4
+%patch32 -p1 -b .bz1118008.1
+%patch33 -p1 -b .bz1118008.2
 
 %build
 ./autogen.sh
@@ -72,7 +141,7 @@ CFLAGS="$(echo '%{optflags}')" make %{_smp_mflags}
 
 %install
 rm -rf %{buildroot}
-make -C fence/agents install DESTDIR=%{buildroot}
+make install DESTDIR=%{buildroot}
 
 ## tree fix up
 # fix libfence permissions
@@ -97,12 +166,100 @@ power management for several devices.
 %defattr(-,root,root,-)
 %doc doc/COPYING.* doc/COPYRIGHT doc/README.licence
 %{_sbindir}/fence*
-%{_libexecdir}/fence*
 %{_datadir}/fence
 %{_datadir}/cluster
 %{_mandir}/man8/fence*
 
 %changelog
+* Thu Mar 26 2015 Marek Grac <mgrac@redhat.com> - 4.0.15-8
+- fix fence2rng to handle quotes
+  Resolves: rhbz#1118008
+
+* Tue Mar 24 2015 Marek Grac <mgrac@redhat.com> - 4.0.15-7
+- fence_scsi: remove new pythonic version
+- fence_ipmilan: unset default cipher
+- fence_ilo2: add options --tls1.0
+- fence_bladecenter: fix login process
+  Resolves: rhbz#1049805
+
+* Mon Mar 02 2015 Marek Grac <mgrac@redhat.com> - 4.0.15-6
+- fence_kdump: Fix problems found by Coverity
+  Resolves: rhbz#1094515
+
+* Thu Feb 26 2015 Marek Grac <mgrac@redhat.com> - 4.0.15-5
+- fence_ilo_ssh: New fence agent
+  Resolves: rhbz#1111482
+- fence_kdump: Update metadata for 'monitor'
+  Resolves: rhbz#1094515
+
+* Wed Feb 25 2015 Marek Grac <mgrac@redhat.com> - 4.0.15-4
+- fence_ilo_moonshot: New fence agent for HP Moonshot
+  Resolves: rhbz#1099551
+- fence_mpath: New fence agent for multipath devices
+  Resolves: rhbz#1118008
+
+* Wed Feb 25 2015 Marek Grac <mgrac@redhat.com> - 4.0.15-3
+- fence_kdump: Doesn't support 'monitor'
+  Resolves: rhbz#1094515
+
+* Thu Feb 19 2015 Marek Grac <mgrac@redhat.com> - 4.0.15-2
+- rebase of fence agents with reverts for backward compatibility
+  Resolves: rhbz#1049805
+
+* Wed Feb 18 2015 Marek Grac <mgrac@redhat.com> - 4.0.15-1
+- rebase of fence agents with reverts for backward compatibility
+  Resolves: rhbz#1049805
+
+* Thu Jul 10 2014 Marek Grac <mgrac@redhat.com> - 3.0.15-48
+- fencing: fix issue with "io_fencing" in metadata
+  Resolves: rhbz#1114559
+
+* Wed Jul 02 2014 Marek Grac <mgrac@redhat.com> - 3.0.15-47
+- fence_brocade: add support for list to allow monitor
+  Resolves: rhbz#1114528
+
+* Tue Jul 01 2014 Marek Grac <mgrac@redhat.com> - 3.0.15-44
+- fence_brocade: fix default action
+  Resolves: rhbz#1114559
+- fence_brocade: add support for list to allow monitor
+  Resolves: rhbz#1114528
+
+* Thu Jun 26 2014 Marek Grac <mgrac@redhat.com> - 3.0.15-43
+- fix quoes in fence_ilo
+  Resolves: rhbz#990537
+- fix delay support for agents without off/reboot
+  Resolves: rhbz#641632
+
+* Mon Jun 23 2014 Marek Grac <mgrac@redhat.com> - 3.0.15-42
+- fence_scsi_check can do hard reboot now
+  Resolves: rhbz#1050022
+
+* Fri Jun 20 2014 Marek Grac <mgrac@redhat.com> - 3.0.15-41
+- fence_brocade ported to fencing library
+  Resolves: rhbz#641632 rhbz#642232 rhbz#841556
+- fence_rsb fails to power devices on with certain firmwares
+  Resolves: rhbz#1110428
+
+* Wed Jun 18 2014 Marek Grac <mgrac@redhat.com> - 3.0.15-40
+- fencing: Add option --ssh-options
+  Resolves: rhbz#1069618
+- fence_vmware_soap: python exception when user does not have privileges
+  Resolves: rhbz#1018263
+- fence_wti: Add support for delay
+  Resolves: rhbz#1079291
+- fence_ilo: Unable to enter password with "
+  Resolves: rhbz#990537
+- fencing: Fence agent uses key authentication when it should use password
+  Resolves: rhbz#1048842
+
+* Fri Mar 14 2014 Marek Grac <mgrac@redhat.com> - 3.0.15-39
+- fencing: fix exception when identity file is used
+  Resolves: rhbz#1075683
+
+* Fri Jan 24 2014 Marek Grac <mgrac@redhat.com> - 3.0.15-38
+- fence_vmware_soap: Add delay option
+  Resolves: rhbz#1051159
+
 * Mon Oct 07 2013 Marek Grac <mgrac@redhat.com> - 3.0.15-35
 - fence_vmware_soap: Fix symlink vulnerability caused by python-suds temp directory
   Resolves: rhbz#1014000
@@ -121,7 +278,7 @@ power management for several devices.
 - fencing: Improve detection of EOL during login
   Resolves: rhbz#886614
 
-* Wed Jul 18 2013 Marek Grac <mgrac@redhat.com> - 3.0.15-31
+* Thu Jul 18 2013 Marek Grac <mgrac@redhat.com> - 3.0.15-31
 - improve description of lanplus parameter in fence ipmilan agent
   Resolves: rhbz#981086
 
@@ -339,7 +496,7 @@ power management for several devices.
   (fence_cisco_ucs-Fix-for-support-for-sub-organization.patch)
   Resolves: rhbz#678904
 
-* Mon Mar 20 2011 Marek Grac <mgrac@redhat.com> - 3.0.12-21
+* Mon Mar 21 2011 Marek Grac <mgrac@redhat.com> - 3.0.12-21
 - fence_rhevm: Update URL for RHEV-M REST API
   (fence_rhevm-Update-URL-to-RHEV-M-REST-API.patch)
   Resolves: rhbz#681674

--- a/SPECS/RHEL6/fence-agents.spec
+++ b/SPECS/RHEL6/fence-agents.spec
@@ -22,6 +22,7 @@ Group: System Environment/Base
 URL: http://sources.redhat.com/cluster/wiki/
 Source0: %{name}-%{version}.tar.bz2
 
+Patch0: 0021-revert.patch
 
 ExclusiveArch: i686 x86_64
 
@@ -63,6 +64,7 @@ BuildRequires: device-mapper-multipath
 %prep
 %setup -q -n %{name}-%{version}
 
+%patch0 -p1 -b .revert21
 
 %build
 ./autogen.sh

--- a/SPECS/RHEL6/pcs.spec
+++ b/SPECS/RHEL6/pcs.spec
@@ -5,11 +5,10 @@ License: GPLv2
 URL: http://github.com/feist/pcs
 Group: System Environment/Base
 ExclusiveArch: i686 x86_64
-BuildRequires: python2-devel rubygems ruby-devel pam-devel
-Requires: ruby rubygems ccs
-Requires: python-clufter
+BuildRequires: python2-devel ruby-devel pam-devel
+Requires: ruby
 Summary: Pacemaker Configuration System	
-Source0: http://people.redhat.com/cfeist/pcs/pcs-withgems-%{version}.tar.gz
+Source0: pcs-%{version}.tar.gz
 
 %description
 pcs is a corosync and pacemaker configuration tool.  It permits users to
@@ -22,6 +21,7 @@ easily view, modify and created pacemaker based clusters.
 
 %install
 rm -rf $RPM_BUILD_ROOT
+export BUILD_GEMS=false
 make install DESTDIR=$RPM_BUILD_ROOT PYTHON_SITELIB=%{python_sitelib}
 make install_pcsd DESTDIR=$RPM_BUILD_ROOT PYTHON_SITELIB=%{python_sitelib} hdrdir="%{_includedir}" rubyhdrdir="%{_includedir}" includedir="%{_includedir}" initdir="%{_initrddir}"
 chmod 755 $RPM_BUILD_ROOT/%{python_sitelib}/pcs/pcs.py
@@ -44,8 +44,6 @@ fi
 %{python_sitelib}/pcs-%{version}-py2.*.egg-info
 /usr/sbin/pcs
 /usr/lib/pcsd/*
-/usr/lib/pcsd/.bundle/config
-/usr/lib/pcsd/.gitignore
 %{_initrddir}/pcsd
 /var/lib/pcsd
 /etc/pam.d/pcsd

--- a/SPECS/RHEL6/pcs.spec
+++ b/SPECS/RHEL6/pcs.spec
@@ -1,6 +1,6 @@
 Name: pcs		
-Version: 0.9.139
-Release: 8%{?dist}
+Version: 0.9.141
+Release: 1%{?dist}
 License: GPLv2
 URL: http://github.com/feist/pcs
 Group: System Environment/Base
@@ -10,12 +10,6 @@ Requires: ruby rubygems ccs
 Requires: python-clufter
 Summary: Pacemaker Configuration System	
 Source0: http://people.redhat.com/cfeist/pcs/pcs-withgems-%{version}.tar.gz
-Patch0: bz1184763-Warn-if-node-removal-will-cause-a-loss-of-the-quorum.patch
-Patch1: bz1168982-Fix-standby-unstandby-local-node.patch
-Patch2: bz1171312-1-Fix-tarball-creation-on-import-cman.patch
-Patch3: bz1171312-2-Fix-passing-parameters-to-python-clufter.patch
-Patch4: rhel6.patch
-Patch5: disable-gui.patch
 
 %description
 pcs is a corosync and pacemaker configuration tool.  It permits users to
@@ -23,12 +17,6 @@ easily view, modify and created pacemaker based clusters.
 
 %prep
 %setup -q
-%patch0 -p1
-%patch1 -p1
-%patch2 -p1
-%patch3 -p1
-%patch4 -p1 -b .rhel6
-%patch5 -p1 -b .disable-gui
 
 %build
 

--- a/SPECS/RHEL6/pcs.spec
+++ b/SPECS/RHEL6/pcs.spec
@@ -1,15 +1,21 @@
 Name: pcs		
-Version: 0.9.90
-Release: 2%{?dist}
+Version: 0.9.139
+Release: 8%{?dist}
 License: GPLv2
 URL: http://github.com/feist/pcs
 Group: System Environment/Base
-BuildArch: noarch
-BuildRequires: python2-devel
+ExclusiveArch: i686 x86_64
+BuildRequires: python2-devel rubygems ruby-devel pam-devel
+Requires: ruby rubygems ccs
+Requires: python-clufter
 Summary: Pacemaker Configuration System	
-Source0: pcs-%{version}.tar.gz
-
-Requires: pacemaker
+Source0: http://people.redhat.com/cfeist/pcs/pcs-withgems-%{version}.tar.gz
+Patch0: bz1184763-Warn-if-node-removal-will-cause-a-loss-of-the-quorum.patch
+Patch1: bz1168982-Fix-standby-unstandby-local-node.patch
+Patch2: bz1171312-1-Fix-tarball-creation-on-import-cman.patch
+Patch3: bz1171312-2-Fix-passing-parameters-to-python-clufter.patch
+Patch4: rhel6.patch
+Patch5: disable-gui.patch
 
 %description
 pcs is a corosync and pacemaker configuration tool.  It permits users to
@@ -17,28 +23,194 @@ easily view, modify and created pacemaker based clusters.
 
 %prep
 %setup -q
+%patch0 -p1
+%patch1 -p1
+%patch2 -p1
+%patch3 -p1
+%patch4 -p1 -b .rhel6
+%patch5 -p1 -b .disable-gui
 
 %build
 
-
 %install
 rm -rf $RPM_BUILD_ROOT
-pwd
 make install DESTDIR=$RPM_BUILD_ROOT PYTHON_SITELIB=%{python_sitelib}
+make install_pcsd DESTDIR=$RPM_BUILD_ROOT PYTHON_SITELIB=%{python_sitelib} hdrdir="%{_includedir}" rubyhdrdir="%{_includedir}" includedir="%{_includedir}" initdir="%{_initrddir}"
 chmod 755 $RPM_BUILD_ROOT/%{python_sitelib}/pcs/pcs.py
 
+%post
+/sbin/chkconfig --add pcsd
+if [ $1 -eq 2 ]; then
+    /sbin/service pcsd condrestart
+fi
+
+%preun
+if [ $1 -eq 0 ]; then
+    /sbin/chkconfig --del pcsd
+    /sbin/service pcsd stop
+fi
 
 %files
 %defattr(-,root,root,-)
 %{python_sitelib}/pcs
 %{python_sitelib}/pcs-%{version}-py2.*.egg-info
 /usr/sbin/pcs
+/usr/lib/pcsd/*
+/usr/lib/pcsd/.bundle/config
+/usr/lib/pcsd/.gitignore
+%{_initrddir}/pcsd
+/var/lib/pcsd
+/etc/pam.d/pcsd
 /etc/bash_completion.d/pcs
+/etc/logrotate.d/pcsd
+%dir /var/log/pcsd
+/etc/sysconfig/pcsd
 %{_mandir}/man8/pcs.*
 
 %doc COPYING README
 
 %changelog
+* Fri Apr 03 2015 Tomas Jelinek <tojeline@redhat.com> - 0.9.139-8
+- Fixed duplicated nodes in a cluster created by import-cman
+- Resolves: rhbz#1171312
+
+* Wed Apr 01 2015 Tomas Jelinek <tojeline@redhat.com> - 0.9.139-7
+- Fixed tarball creation on import-cman
+- Resolves: rhbz#1171312
+
+* Wed Mar 25 2015 Tomas Jelinek <tojeline@redhat.com> - 0.9.139-6
+- Fixed node standby / unstadby
+- Resolves: rhbz#1168982
+
+* Fri Mar 13 2015 Tomas Jelinek <tojeline@redhat.com> - 0.9.139-5
+- Added dependency on python-clufter
+- Resolves: rhbz#1171312
+
+* Thu Mar 05 2015 Chris Feist <cfeist@redhat.com> - 0.9.139-4
+- Revert clufter changes since it will be in its own package
+- Resolves: rhbz#1171312
+
+* Wed Mar 04 2015 Tomas Jelinek <tojeline@redhat.com> - 0.9.139-3
+- Added clufter package
+- Resolves: rhbz#1171312
+
+* Mon Mar 02 2015 Tomas Jelinek <tojeline@redhat.com> - 0.9.139-2
+- Added warning when node removal will cause a loss of the quorum
+- Resolves: rhbz#1184763
+
+* Tue Feb 17 2015 Tomas Jelinek <tojeline@redhat.com> - 0.9.139-1
+- Rebased to latest upstream packages
+- Fixed constraints removal and node standby/unstandby using remote GUI
+- Fixed displaying of fence / resource agent metadata in GUI
+- Added Pacemaker Resource defaults and Op defaults to 'pcs config' output
+- Fixed 'pcs resource clear' used on cloned group
+- Added support for scope option in cib commands
+- Added warning when creating a cluster with UDPU transport
+- Reload cluster.conf after node addition / removal
+- Resolves: rhbz#1185738 rhbz#1168982 rhbz#1174793 rhbz#1187488 rhbz#1190167 rhbz#1190168 rhbz#1191898 rhbz#1193433
+
+* Tue Jan 27 2015 Tomas Jelinek <tojeline@redhat.com> - 0.9.138-1
+- Rebased to latest upstream packages
+- Fixed creating default resource operations
+- Added support for RRP and corosync options for cman based clusters
+- Allowed scope=configuration in cib commands
+- Added support for configuring a cluster remotely using pcsd
+- Fixed globally-unique clone resources in pcsd
+- Added resource location to resources / stonith devices list
+- Fixed formatting of resource / fence agent description
+- Fence agent description now contains information about the agent
+- Parallelized cluster start and cluster stop
+- Added warning when nodes stop will cause a loss of the quorum
+- pcs status --full now displays Node attributes and Migration summary
+- Resolves: rhbz#1185738 rhbz#1031141 rhbz#1121769 rhbz#1126835 rhbz#1160359 rhbz#1168986 rhbz#1174244 rhbz#1174793 rhbz#1174798 rhbz#1174801 rhbz#1184763 rhbz#1184922
+
+* Wed Aug 27 2014 Chris Feist <cfeist@redhat.cmo> - 0.9.123-9
+- Improved detection of RHEL 6 variants
+- Resolves: rhbz#1026431
+
+* Fri Aug 15 2014 Chris Feist <cfeist@redhat.cmo> - 0.9.123-8
+- Added support for 'pcs acl' and 'pcs config' in bash completion
+- Resolves: rhbz#1026987
+
+* Wed Aug 13 2014 Chris Feist <cfeist@redhat.com> - 0.9.123-7
+- Fixed error in bash completion when an '|' is used
+- Resolves: rhbz#1026987
+
+* Thu Aug 07 2014 Chris Feist <cfeist@redhat.com> - 0.9.123-6
+- Fixed issue with sync cluster.conf & adding uid/gid across cluster on RHEL6 w/ pcsd
+- Resolves: rhbz#1102836
+
+* Wed Aug 06 2014 Chris Feist <cfeist@redhat.com> - 0.9.123-5
+- Fixed support for adding/removing nodes on RHEL6 w/ pcsd
+- Resolves: rhbz#1102836
+
+* Thu Jul 03 2014 Chris Feist <cfeist@redhat.com> - 0.9.123-4
+- Fixed resource delete for clones of groups with more than one resource
+- Fixed unclone of group so all resources are removed
+- Resolves: rhbz#1107612 rhbz#1108778
+
+* Tue Jul 01 2014 Chris Feist <cfeist@redhat.com> - 0.9.123-3
+- Added ability to upgrade cluster cib and we auto upgrade cib if we're running
+  an acl command (except show or help)
+- Resolves: rhbz#1112727
+
+* Mon Jun 23 2014 Chris Feist <cfeist@redhat.com> - 0.9.123-2
+- Added --full to pcs status to view resources in clones of groups
+- Resolves: rhbz#1033538
+
+* Thu Jun 19 2014 Chris Feist <cfeist@redhat.com> - 0.9.123-1
+- Added support for pacemaker ACLs
+- Resolves: rhbz#1102836
+
+* Mon Jun 16 2014 Chris Feist <cfeist@redhat.com> - 0.9.122-4
+- Fixed pcs cluster enable/disable to only enable pacemaker
+- Resolves: rhbz#1038107
+
+* Fri Jun 13 2014 Chris Feist <cfeist@redhat.com> - 0.9.122-3
+- Disabled GUI
+- On upgrade, condrestart pcsd
+- Resolves: rhbz#1102836
+
+* Wed Jun 11 2014 Chris Feist <cfeist@redhat.com> - 0.9.121-1
+- Don't try to get metadata for fence_check, fence_tool & fence_node
+- Cloned M/S groups can now be deleted
+- Clone options can now follow --clone
+- Cloned resources with globally-unique=true can now be deleted
+- Resolves: rhbz#1102836
+
+* Tue Jun 10 2014 Chris Feist <cfeist@redhat.com> - 0.9.120-2
+- Use /usr/sbin/pcs for pcs instead of /sbin/pcs
+- Use Open4 instead of POpen4 for running commands
+- Fixed cluster setup for RHEL6
+- Resolves: rhbz#1102836
+
+* Mon Jun 09 2014 Chris Feist <cfeist@redhat.com> - 0.9.118-2
+- Re-synced to upstream sources
+- Fixed dependency on rubygems
+- Fixed pam long timeouts due to fprintd
+- Resolves: rhbz#1102836
+
+* Thu Jun 05 2014 Chris Feist <cfeist@redhat.com> - 0.9.117-1
+- Fixed gem install order
+- Use local gems for install
+- Resolves: rhbz#1102836
+
+* Thu Jun 05 2014 Chris Feist <cfeist@redhat.com> - 0.9.116-1
+- Re-synced to latest upstream source
+- Added support for pcsd
+- Resolves: rhbz#1102836
+
+* Tue May 20 2014 Chris Feist <cfeist@redhat.com> - 0.9.101-3
+- When creating a resource using --group/--clone/--master put the group
+  inside the master/clone/group before putting it into the live CIB
+- Resolves: rhbz#1066927
+
+* Wed Dec 04 2013 Chris Feist <cfeist@redhat.com> - 0.9.101-1
+- Rebase for new features
+- Added ability to set uidgid in cluster.conf
+- Stonith level add now properly recognizes nodes
+- Resolves: rhbz#1025053 rhbz#1019410
+
 * Fri Oct 11 2013 Chris Feist <cfeist@redhat.com> - 0.9.90-2
 - Bump version for 6.4.z stream
 

--- a/make-repo.conf
+++ b/make-repo.conf
@@ -75,7 +75,7 @@ SRC_FILES="$SRC_FILES pm_diskd pm_extras pm_crmgen pm_logconv-cs pm_ctl"
 
 ##  pcs
 BIN_FILES="$BIN_FILES pcs"
-#DEBUG_FILES="$DEBUG_FILES "
+DEBUG_FILES="$DEBUG_FILES pcs-debuginfo"
 SRC_FILES="$SRC_FILES pcs"
 
 ##  fence-agents


### PR DESCRIPTION
Update spec files of pcs and fence-agents for el6.

Changes include:
* fence-agents: fence_kdump_send is now installed to /usr/sbin on el6
* pcs: pcs is now built as x86_64 arch and pcs-debuginfo package is added (both on el6/el7)
